### PR TITLE
Regex fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 */__pycache__
+*.tar
+*.tar.gz

--- a/bin/args.py
+++ b/bin/args.py
@@ -1,5 +1,5 @@
 import argparse
-import re
+
 
 def get_args():
     """

--- a/bin/args.py
+++ b/bin/args.py
@@ -1,16 +1,6 @@
 import argparse
 import re
 
-
-def sanitize_job_name(job_name: str) -> None:
-    """
-    Make sure the job name doesn't contain forbidden characters
-    """
-    if not re.match("[a-zA-Z_:][a-zA-Z0-9_:]*", job_name):
-        print("The Prometheus job name does not match the required format")
-        exit(0)
-
-
 def get_args():
     """
     Parse the logging path and the job name

--- a/bin/prometheus.py
+++ b/bin/prometheus.py
@@ -20,9 +20,7 @@ class Prometheus:
         self.jobname = jobname
         self.metrics = []
         self.ppid = os.getppid()
-        self.error_filename = (
-            f"{self.out_path}/{self.ppid}_{date.datetime.now()}.err"
-        )
+        self.error_filename = f"{self.out_path}/{str(date.datetime.now())}.err"
         self.temp_filename = f"{self.out_path}/{self.jobname}.prom.{self.ppid}"
 
     def error_if_job_name_invalid(self) -> None:
@@ -33,11 +31,12 @@ class Prometheus:
         """
         regex_pattern = "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
         if not re.match(regex_pattern, self.jobname):
-            error = f"The Prometheus job name does not match the required "
-            f"format - it must match the regex {regex_pattern}"
+            error = f"The Prometheus job name {self.jobname} does not match "
+            f"the Prometheus data model requirements - it needs to match "
+            f"the regex {regex_pattern}"
             with open(self.error_filename, "a") as new_file:
                 new_file.write(error)
-            os.chmod(new_file, int("644", base=8))
+            os.chmod(self.error_filename, int("644", base=8))
             exit(0)
 
     def format_metrics(self) -> None:

--- a/bin/prometheus.py
+++ b/bin/prometheus.py
@@ -31,9 +31,11 @@ class Prometheus:
         """
         regex_pattern = "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
         if not re.match(regex_pattern, self.jobname):
-            error = f"The Prometheus job name {self.jobname} does not match "
-            + f"the Prometheus data model requirements - it needs to match "
-            + f"the regex {regex_pattern}"
+            error = (
+                f"The Prometheus job name {self.jobname} does not match "
+                + f"the Prometheus data model requirements - it needs to match "
+                + f"the regex {regex_pattern}"
+            )
             with open(self.error_filename, "a") as new_file:
                 new_file.write(error)
             os.chmod(self.error_filename, int("644", base=8))

--- a/bin/prometheus.py
+++ b/bin/prometheus.py
@@ -32,8 +32,8 @@ class Prometheus:
         regex_pattern = "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
         if not re.match(regex_pattern, self.jobname):
             error = f"The Prometheus job name {self.jobname} does not match "
-            f"the Prometheus data model requirements - it needs to match "
-            f"the regex {regex_pattern}"
+            + f"the Prometheus data model requirements - it needs to match "
+            + f"the regex {regex_pattern}"
             with open(self.error_filename, "a") as new_file:
                 new_file.write(error)
             os.chmod(self.error_filename, int("644", base=8))

--- a/bin/prometheus.py
+++ b/bin/prometheus.py
@@ -2,6 +2,7 @@ import datetime as date
 import glob
 from pathlib import Path
 import os
+import re
 
 
 class Prometheus:
@@ -9,18 +10,31 @@ class Prometheus:
     A class for formatting and writing logs which are readible by Prometheus
     monitoring software. Currently this only logs a 'job completed' message.
     """
-
     def __init__(
         self,
         out_path: str,
         jobname: str,
     ):
         self.out_path = out_path
-        # make sure jobname matches Prom data model (no hyphens)
         self.jobname = jobname
         self.metrics = []
         self.ppid = os.getppid()
+        self.error_filename = f"{self.out_path}/{self.ppid}_{date.datetime.now()}.err"
         self.temp_filename = f"{self.out_path}/{self.jobname}.prom.{self.ppid}"
+
+    def error_if_job_name_invalid(self) -> None:
+        """
+        Check the job name for forbidden characters.
+        Error out with a logged message if not. Make this read-accessible to
+        non-cron users.
+        """
+        if not re.match("^[a-zA-Z_:][a-zA-Z0-9_:]*$", self.jobname):
+            error = "The Prometheus job name does not match the required "
+            "format - it must match the regex ^[a-zA-Z_:][a-zA-Z0-9_:]*$"
+            with open(self.error_filename, "a") as new_file:
+                new_file.write(error)
+            os.chmod(new_file, int("644", base=8))
+            exit(0)
 
     def format_metrics(self) -> None:
         """

--- a/bin/prometheus.py
+++ b/bin/prometheus.py
@@ -10,6 +10,7 @@ class Prometheus:
     A class for formatting and writing logs which are readible by Prometheus
     monitoring software. Currently this only logs a 'job completed' message.
     """
+
     def __init__(
         self,
         out_path: str,
@@ -19,7 +20,9 @@ class Prometheus:
         self.jobname = jobname
         self.metrics = []
         self.ppid = os.getppid()
-        self.error_filename = f"{self.out_path}/{self.ppid}_{date.datetime.now()}.err"
+        self.error_filename = (
+            f"{self.out_path}/{self.ppid}_{date.datetime.now()}.err"
+        )
         self.temp_filename = f"{self.out_path}/{self.jobname}.prom.{self.ppid}"
 
     def error_if_job_name_invalid(self) -> None:
@@ -28,9 +31,10 @@ class Prometheus:
         Error out with a logged message if not. Make this read-accessible to
         non-cron users.
         """
-        if not re.match("^[a-zA-Z_:][a-zA-Z0-9_:]*$", self.jobname):
-            error = "The Prometheus job name does not match the required "
-            "format - it must match the regex ^[a-zA-Z_:][a-zA-Z0-9_:]*$"
+        regex_pattern = "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
+        if not re.match(regex_pattern, self.jobname):
+            error = f"The Prometheus job name does not match the required "
+            f"format - it must match the regex {regex_pattern}"
             with open(self.error_filename, "a") as new_file:
                 new_file.write(error)
             os.chmod(new_file, int("644", base=8))

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from bin.args import get_args
 def main():
     args = get_args()
     prom = Prometheus("/prom_metrics", args.job_name)
+    prom.error_if_job_name_invalid()
     prom.format_metrics()
     prom.emit_temp_metrics()
     prom.replace_old_metrics()


### PR DESCRIPTION
## Changes:
During pre-release testing, it was found that badly-formatted job names were not throwing errors as expected. This was due to re.match not containing ^ and $ to specify the full length of the job name.

- Move job name sanitising function into Prometheus class, and add ^$ to regex
- Produce .err files
- Call the sanitising function in main


## Test set up:
sudo docker build -t komodo_cron_metrics:regex_fix .

sudo docker image ls | grep "komodo_cron_metrics"
komodo_cron_metrics                          regex_fix       a2be5e07c228   6 minutes ago    1.03GB


## Test the error state:
"test-10" should be detected as invalid, because of the hyphen
Only a .err file should be produced
This WON'T be picked up by Prometheus - monitored jobs will not show up in Grafana, prompting investigation

corbin@starling:~/wc/test_komodo_cron$ sudo docker run --rm -v /home/corbin/wc/test_komodo_cron:/prom_metrics a2be5e07c228 "test-10"

corbin@starling:~/wc/test_komodo_cron$ ls -l
total 4
-rw-r--r-- 1 root root 142 May 31 12:09 '2024-05-31 11:09:42.532808.err'

corbin@starling:~/wc/test_komodo_cron$ head 2024-05-31\ 11\:09\:42.532808.err 
The Prometheus job name test-10 does not match the Prometheus data model requirements - it needs to match the regex ^[a-zA-Z_:][a-zA-Z0-9_:]*$

Test passed: The .err file was produced, and no .prom file was made


## Test the correct format state:
"test10" should pass as a valid string
Only a .prom file is produced
The .prom file should contain a metric in the format: jobname_completed epochtime

corbin@starling:~/wc/test_komodo_cron$ sudo docker run --rm -v /home/corbin/wc/test_komodo_cron:/prom_metrics a2be5e07c228 "test10"

corbin@starling:~/wc/test_komodo_cron$ ls -l
total 8
-rw-r--r-- 1 root root 142 May 31 12:09 '2024-05-31 11:09:42.532808.err'
-rw-r--r-- 1 root root  28 May 31 12:11  test10.prom

corbin@starling:~/wc/test_komodo_cron$ head test10.prom 
test10_completed 1717153898

Test passed: The .prom metric was created successfully. There's no .err file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/komodo_cron_metrics/2)
<!-- Reviewable:end -->
